### PR TITLE
feat: bootstrap simoem monorepo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DATABASE_PROVIDER=sqlite
+DATABASE_URL=file:./dev.db
+PORT=3333
+WEB_ORIGIN=http://localhost:5173

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier'
+  ],
+  ignorePatterns: ['dist', 'build', 'coverage'],
+  env: {
+    node: true,
+    browser: true,
+    es2021: true
+  }
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8.15.4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter engine test
+      - run: pnpm --filter api test -- --runInBand
+      - run: pnpm --filter web test -- --runInBand

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.pnpm-store
+/dist
+/build
+/apps/api/dist
+/apps/web/dist
+coverage
+.env
+.DS_Store

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+pnpm lint-staged

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,0 +1,9 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json pnpm-lock.yaml* pnpm-workspace.yaml* ./
+RUN npm install -g pnpm@8.15.4
+COPY . ./
+RUN pnpm install --frozen-lockfile
+WORKDIR /app/apps/api
+RUN pnpm build || true
+CMD ["pnpm", "dev"]

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json pnpm-lock.yaml* pnpm-workspace.yaml* ./
+RUN npm install -g pnpm@8.15.4
+COPY . ./
+RUN pnpm install --frozen-lockfile
+WORKDIR /app/apps/web
+CMD ["pnpm", "dev", "--", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# SIM-OEM
+# SimOEM
+
+SimOEM is a Maxis-inspired automotive OEM simulation. This repository hosts a pnpm workspace monorepo with a deterministic simulation engine, an Express API, and a React + Vite front-end.
+
+## Getting Started
+
+```bash
+pnpm install
+pnpm db:migrate
+pnpm db:seed
+pnpm dev
+```
+
+See [`docs/INSTALL.md`](docs/INSTALL.md) for full instructions.

--- a/apps/api/jest.config.ts
+++ b/apps/api/jest.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+};
+
+export default config;

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "api",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "tsx watch src/main.ts",
+    "build": "tsup src/main.ts --dts",
+    "start": "node dist/index.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@prisma/client": "5.9.1",
+    "cors": "2.8.5",
+    "dotenv": "16.4.1",
+    "express": "4.18.2",
+    "express-async-errors": "3.1.1",
+    "http-errors": "2.0.0",
+    "engine": "workspace:*",
+    "seedrandom": "3.0.5",
+    "zod": "3.22.4"
+  },
+  "devDependencies": {
+    "@types/cors": "2.8.17",
+    "@types/express": "4.17.21",
+    "@types/http-errors": "2.0.4",
+    "@types/jest": "29.5.11",
+    "@types/node": "20.11.19",
+    "jest": "29.7.0",
+    "supertest": "6.3.4",
+    "ts-jest": "29.1.1",
+    "ts-node": "10.9.2",
+    "tsup": "7.2.0",
+    "tsx": "4.7.1",
+    "typescript": "5.3.3"
+  }
+}

--- a/apps/api/src/__tests__/sim.test.ts
+++ b/apps/api/src/__tests__/sim.test.ts
@@ -1,0 +1,30 @@
+import request from 'supertest';
+import express from 'express';
+import { SimService } from '../simService.js';
+import type { PrismaClient } from '@prisma/client';
+
+describe('Sim API', () => {
+  it('returns validation error when plan invalid', async () => {
+    const prisma = {
+      simConfig: { findFirst: async () => null },
+      trim: { findMany: async () => [] },
+      market: { findMany: async () => [] },
+      plant: { findMany: async () => [] },
+    } as unknown as PrismaClient;
+    const service = new SimService(prisma);
+    const app = express();
+    app.use(express.json());
+    app.post('/api/actions/plan', async (req, res) => {
+      try {
+        const plan = await service.submitPlan(req.body);
+        res.json({ plan });
+      } catch (error: any) {
+        res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: error.message } });
+      }
+    });
+
+    const response = await request(app).post('/api/actions/plan').send({ pricing: [{}] });
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe('VALIDATION_ERROR');
+  });
+});

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -1,0 +1,8 @@
+import { config } from 'dotenv';
+
+config();
+
+export const PORT = Number(process.env.PORT ?? 3333);
+export const WEB_ORIGIN = process.env.WEB_ORIGIN ?? 'http://localhost:5173';
+export const DATABASE_URL = process.env.DATABASE_URL ?? 'file:./dev.db';
+export const DATABASE_PROVIDER = process.env.DATABASE_PROVIDER ?? 'sqlite';

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,0 +1,85 @@
+import 'express-async-errors';
+import express from 'express';
+import cors from 'cors';
+import { PrismaClient } from '@prisma/client';
+import { PORT, WEB_ORIGIN } from './env.js';
+import { SimService } from './simService.js';
+import { openApiSpec } from './openapi.js';
+import createHttpError from 'http-errors';
+
+const prisma = new PrismaClient();
+const service = new SimService(prisma);
+const app = express();
+
+app.use(express.json());
+app.use(cors({ origin: WEB_ORIGIN }));
+
+app.get('/openapi.json', (_req, res) => {
+  res.json(openApiSpec);
+});
+
+app.get('/api/sim/config', async (_req, res) => {
+  const cfg = await service.getConfig();
+  res.json(cfg);
+});
+
+app.post('/api/sim/new', async (_req, res) => {
+  const snapshot = await service.startNewSim();
+  res.json(snapshot);
+});
+
+app.post('/api/actions/plan', async (req, res) => {
+  try {
+    const plan = await service.submitPlan(req.body);
+    res.json({ plan });
+  } catch (error: any) {
+    res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: error.message } });
+  }
+});
+
+app.post('/api/sim/tick', async (_req, res, next) => {
+  try {
+    const snapshot = await service.advanceTick();
+    res.json(snapshot);
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.get('/api/sim/state', async (_req, res) => {
+  const state = await service.getActiveState();
+  res.json(state ?? null);
+});
+
+app.get('/api/sim/history', async (req, res) => {
+  const from = req.query.from ? Number(req.query.from) : undefined;
+  const to = req.query.to ? Number(req.query.to) : undefined;
+  const history = await service.history(from, to);
+  res.json(history);
+});
+
+app.post('/api/save', async (_req, res) => {
+  res.json({ ok: true });
+});
+
+app.get('/api/save', async (_req, res) => {
+  res.json([]);
+});
+
+app.post('/api/load', async (_req, res) => {
+  const snapshot = await service.startNewSim();
+  res.json(snapshot);
+});
+
+app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  if (createHttpError.isHttpError(err)) {
+    res.status(err.status).json({ error: { code: err.name, message: err.message } });
+    return;
+  }
+  console.error(err);
+  res.status(500).json({ error: { code: 'INTERNAL_ERROR', message: 'Unexpected server error' } });
+});
+
+app.listen(PORT, () => {
+  console.log(`API listening on http://localhost:${PORT}`);
+});

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -1,0 +1,68 @@
+export const openApiSpec = {
+  openapi: '3.0.1',
+  info: {
+    title: 'SimOEM API',
+    version: '1.0.0',
+  },
+  servers: [{ url: 'http://localhost:3333' }],
+  paths: {
+    '/api/sim/config': {
+      get: {
+        operationId: 'getSimConfig',
+        responses: {
+          '200': { description: 'Sim config' },
+        },
+      },
+    },
+    '/api/sim/new': {
+      post: {
+        operationId: 'startNewSim',
+        responses: { '200': { description: 'New sim started' } },
+      },
+    },
+    '/api/sim/tick': {
+      post: {
+        operationId: 'advanceTick',
+        responses: { '200': { description: 'Sim snapshot' } },
+      },
+    },
+    '/api/sim/state': {
+      get: {
+        operationId: 'getActiveState',
+        responses: { '200': { description: 'State summary' } },
+      },
+    },
+    '/api/sim/history': {
+      get: {
+        operationId: 'getHistory',
+        parameters: [
+          { name: 'from', in: 'query', schema: { type: 'integer' } },
+          { name: 'to', in: 'query', schema: { type: 'integer' } },
+        ],
+        responses: { '200': { description: 'Snapshots window' } },
+      },
+    },
+    '/api/actions/plan': {
+      post: {
+        operationId: 'planActions',
+        responses: { '200': { description: 'Plan accepted' } },
+      },
+    },
+    '/api/save': {
+      post: {
+        operationId: 'saveGame',
+        responses: { '200': { description: 'Saved' } },
+      },
+      get: {
+        operationId: 'listSaves',
+        responses: { '200': { description: 'List saves' } },
+      },
+    },
+    '/api/load': {
+      post: {
+        operationId: 'loadGame',
+        responses: { '200': { description: 'Loaded' } },
+      },
+    },
+  },
+};

--- a/apps/api/src/simService.ts
+++ b/apps/api/src/simService.ts
@@ -1,0 +1,226 @@
+import { PrismaClient } from '@prisma/client';
+import { advanceMonth, SimConfig as EngineSimConfig, SimInputPlan, SimState, SimSnapshot } from 'engine';
+import { z } from 'zod';
+
+const planSchema = z.object({
+  pricing: z
+    .array(
+      z.object({
+        trimId: z.number(),
+        marketId: z.number(),
+        msrp: z.number().optional(),
+        incentivePerUnit: z.number().optional(),
+        aprSubvent: z.number().optional(),
+        leaseMF: z.number().optional(),
+        residualPct: z.number().optional(),
+      })
+    )
+    .default([]),
+  rAndD: z
+    .array(
+      z.object({
+        techNodeId: z.number(),
+        action: z.enum(['start', 'pause', 'cancel']),
+      })
+    )
+    .default([]),
+  contracts: z
+    .array(
+      z.object({
+        supplierId: z.number(),
+        partId: z.number().optional(),
+        action: z.enum(['sign', 'renegotiate', 'terminate']),
+        terms: z.any(),
+      })
+    )
+    .default([]),
+  productionPlan: z
+    .array(
+      z.object({
+        plantId: z.number(),
+        trimId: z.number(),
+        volume: z.number(),
+        month: z.number(),
+      })
+    )
+    .default([]),
+  campaigns: z
+    .array(
+      z.object({
+        marketId: z.number(),
+        type: z.string(),
+        spend: z.number(),
+        startMonth: z.number(),
+        endMonth: z.number(),
+      })
+    )
+    .default([]),
+  allocationRules: z.object({
+    marketPriority: z.record(z.number()),
+    dealerCSIWeight: z.number(),
+    fairnessMin: z.number(),
+  }),
+});
+
+export type ValidatedPlan = z.infer<typeof planSchema>;
+
+export class SimService {
+  private prisma: PrismaClient;
+  private currentConfig: EngineSimConfig | null = null;
+  private activeState: SimState | null = null;
+  private lastSnapshot: SimSnapshot | null = null;
+  private pendingPlan: ValidatedPlan | null = null;
+  private rngSeed = 'sim-oem';
+
+  constructor(prisma: PrismaClient) {
+    this.prisma = prisma;
+  }
+
+  async getConfig(): Promise<EngineSimConfig> {
+    if (!this.currentConfig) {
+      const record = await this.prisma.simConfig.findFirst();
+      this.currentConfig = (record?.rules as EngineSimConfig['rules'])
+        ? ({ name: record?.name ?? 'default', rules: record?.rules as EngineSimConfig['rules'] } as EngineSimConfig)
+        : {
+            name: 'default',
+            rules: {
+              availabilitySigmoid: { mid: 60, steepness: 0.05 },
+              elasticityBySegment: { 'suv-c': 1.0 },
+              baseSegmentDemand: { 'suv-c': 20000 },
+              macroWeights: { gdp: 0.4, interest: -0.5, fuel: 0.3 },
+              logisticCostPerUnit: 650,
+              campaignLiftScalar: 0.00015,
+              warranty: {
+                complexityBase: 1.05,
+                powertrainComplexity: { bev: 1.3, phev: 1.2, hev: 1.15, ice: 1 },
+              },
+              co2: { finePerGram: 50 },
+            },
+          };
+    }
+    return this.currentConfig;
+  }
+
+  async startNewSim(): Promise<SimSnapshot> {
+    const config = await this.getConfig();
+    const trims = await this.prisma.trim.findMany({ include: { program: { include: { segment: true } } } });
+    const markets = await this.prisma.market.findMany({ include: { dealers: true } });
+    const plants = await this.prisma.plant.findMany();
+
+    const state: SimState = {
+      id: 'active',
+      currentMonth: 0,
+      cash: 500_000_000,
+      debt: 100_000_000,
+      boardExpectations: {},
+      trims: trims.map((t) => ({
+        id: `trim-${t.id}`,
+        programId: `prog-${t.programId}`,
+        segmentId: t.program.segment.code,
+        powertrain: t.powertrain,
+        msrp: t.msrp,
+        featureVector: t.featureVector as Record<string, number>,
+        buildCost: t.buildCost as Record<string, number>,
+        batteryKWh: t.batteryKWh ?? undefined,
+        rangeMiles: t.rangeMiles ?? undefined,
+        adasLevel: t.adasLevel,
+        variableMargins: t.variableMargins as Record<string, number>,
+      })),
+      inventories: markets.flatMap((m) =>
+        m.dealers.map((d, index) => ({
+          trimId: `trim-${trims[index % trims.length]?.id ?? trims[0]?.id ?? 1}`,
+          marketId: `market-${m.id}`,
+          dealerId: `dealer-${d.id}`,
+          qty: 120,
+          ageDays: 15,
+        }))
+      ),
+      macro: Object.fromEntries(markets.map((m) => [`market-${m.id}`, { gdpIdx: m.gdpIdx, interestRateIdx: m.interestRateIdx, fuelPriceIdx: m.fuelPriceIdx }])),
+      brandAffinity: Object.fromEntries(markets.map((m) => [`market-${m.id}`, 1])),
+      plants: plants.map((p) => ({
+        id: `plant-${p.id}`,
+        oee: p.oee,
+        changeoverMins: p.changeoverMins,
+        bottlenecks: p.bottlenecks as Record<string, number>,
+      })),
+      warrantyModel: {
+        baseRate: 700,
+        complexityFactor: 1.05,
+        supplierPpmFactor: 1,
+        oeeFactor: 1,
+      },
+      allocationRule: {
+        marketPriority: Object.fromEntries(markets.map((m) => [`market-${m.id}`, 1])),
+        dealerCSIWeight: 1,
+        fairnessMin: 5,
+      },
+    };
+
+    const plan: SimInputPlan = {
+      pricing: [],
+      rAndD: [],
+      contracts: [],
+      productionPlan: [],
+      campaigns: [],
+      allocationRules: state.allocationRule,
+    };
+
+    const { nextState, snapshot } = advanceMonth(state, plan, config, this.rngSeed);
+
+    this.activeState = nextState;
+    this.lastSnapshot = snapshot;
+
+    return snapshot;
+  }
+
+  async getActiveState() {
+    return this.activeState;
+  }
+
+  async submitPlan(planBody: unknown) {
+    const validated = planSchema.parse(planBody);
+    this.pendingPlan = validated;
+    return validated;
+  }
+
+  async advanceTick(): Promise<SimSnapshot> {
+    if (!this.activeState) {
+      throw new Error('No active state');
+    }
+    const config = await this.getConfig();
+    const plan = this.pendingPlan ?? {
+      pricing: [],
+      rAndD: [],
+      contracts: [],
+      productionPlan: [],
+      campaigns: [],
+      allocationRules: this.activeState.allocationRule,
+    };
+
+    const normalizedPlan: SimInputPlan = {
+      pricing: plan.pricing.map((p) => ({ ...p, trimId: `trim-${p.trimId}`, marketId: `market-${p.marketId}` })),
+      rAndD: plan.rAndD.map((r) => ({ ...r, techNodeId: `tech-${r.techNodeId}` })),
+      contracts: plan.contracts.map((c) => ({ ...c, supplierId: `supplier-${c.supplierId}`, partId: c.partId ? `part-${c.partId}` : undefined })),
+      productionPlan: plan.productionPlan.map((pr) => ({ ...pr, plantId: `plant-${pr.plantId}`, trimId: `trim-${pr.trimId}` })),
+      campaigns: plan.campaigns.map((c) => ({ ...c, marketId: `market-${c.marketId}` })),
+      allocationRules: {
+        marketPriority: Object.fromEntries(
+          Object.entries(plan.allocationRules.marketPriority).map(([key, value]) => [`market-${key}`, value])
+        ),
+        dealerCSIWeight: plan.allocationRules.dealerCSIWeight,
+        fairnessMin: plan.allocationRules.fairnessMin,
+      },
+    } as unknown as SimInputPlan;
+
+    const { nextState, snapshot } = advanceMonth(this.activeState, normalizedPlan, config, this.rngSeed);
+    this.activeState = nextState;
+    this.lastSnapshot = snapshot;
+    this.pendingPlan = null;
+    return snapshot;
+  }
+
+  async history(from?: number, to?: number) {
+    if (!this.lastSnapshot) return [];
+    return [this.lastSnapshot];
+  }
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src", "test"]
+}

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SimOEM</title>
+  </head>
+  <body class="bg-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "web",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "5.20.1",
+    "@tanstack/react-router": "1.20.3",
+    "axios": "1.6.7",
+    "engine": "workspace:*",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "recharts": "2.7.2",
+    "zustand": "4.5.0",
+    "tailwindcss": "3.4.1",
+    "clsx": "2.1.0",
+    "@headlessui/react": "1.7.17",
+    "@heroicons/react": "2.1.1"
+  },
+  "devDependencies": {
+    "@types/react": "18.2.46",
+    "@types/react-dom": "18.2.18",
+    "@vitejs/plugin-react": "4.2.1",
+    "autoprefixer": "10.4.16",
+    "postcss": "8.4.33",
+    "tailwindcss": "3.4.1",
+    "typescript": "5.3.3",
+    "vite": "5.0.12",
+    "vitest": "1.2.1",
+    "@testing-library/react": "14.1.2",
+    "@testing-library/jest-dom": "6.2.0"
+  }
+}

--- a/apps/web/postcss.config.cjs
+++ b/apps/web/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/web/src/components/HistoryChart.tsx
+++ b/apps/web/src/components/HistoryChart.tsx
@@ -1,0 +1,24 @@
+import { Card } from 'ui-kit';
+import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+
+type HistoryChartProps = {
+  data: Array<{ month: number; cash: number; sales: number }>;
+};
+
+export function HistoryChart({ data }: HistoryChartProps) {
+  return (
+    <Card title="Financial History">
+      <div className="h-64">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data}>
+            <XAxis dataKey="month" stroke="#94a3b8" />
+            <YAxis stroke="#94a3b8" />
+            <Tooltip />
+            <Line type="monotone" dataKey="cash" stroke="#0f172a" strokeWidth={2} dot={false} />
+            <Line type="monotone" dataKey="sales" stroke="#1d4ed8" strokeWidth={2} dot={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/src/components/KpiTile.tsx
+++ b/apps/web/src/components/KpiTile.tsx
@@ -1,0 +1,17 @@
+import { Card } from 'ui-kit';
+
+type KpiTileProps = {
+  label: string;
+  value: string;
+  helper?: string;
+};
+
+export function KpiTile({ label, value, helper }: KpiTileProps) {
+  return (
+    <Card className="bg-white">
+      <div className="text-xs uppercase tracking-wide text-slate-500">{label}</div>
+      <div className="mt-2 text-2xl font-semibold text-slate-900">{value}</div>
+      {helper && <div className="mt-1 text-xs text-slate-500">{helper}</div>}
+    </Card>
+  );
+}

--- a/apps/web/src/hooks/usePlanStore.ts
+++ b/apps/web/src/hooks/usePlanStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+type PricingPlan = {
+  trimId: number;
+  marketId: number;
+  incentivePerUnit?: number;
+};
+
+type PlanState = {
+  pricing: PricingPlan[];
+  setPricing: (pricing: PricingPlan[]) => void;
+};
+
+export const usePlanStore = create<PlanState>((set) => ({
+  pricing: [],
+  setPricing: (pricing) => set({ pricing }),
+}));

--- a/apps/web/src/hooks/useSimApi.ts
+++ b/apps/web/src/hooks/useSimApi.ts
@@ -1,0 +1,35 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost:3333',
+});
+
+export async function fetchConfig() {
+  const { data } = await api.get('/api/sim/config');
+  return data;
+}
+
+export async function startNewSim() {
+  const { data } = await api.post('/api/sim/new');
+  return data;
+}
+
+export async function fetchState() {
+  const { data } = await api.get('/api/sim/state');
+  return data;
+}
+
+export async function submitPlan(plan: any) {
+  const { data } = await api.post('/api/actions/plan', plan);
+  return data;
+}
+
+export async function tickSim() {
+  const { data } = await api.post('/api/sim/tick');
+  return data;
+}
+
+export async function fetchHistory() {
+  const { data } = await api.get('/api/sim/history');
+  return data;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  font-family: 'Inter', sans-serif;
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Link, Outlet, RouterProvider, createRouter, createRootRoute, createRoute } from '@tanstack/react-router';
+import { DashboardView } from './views/DashboardView';
+import { PlanningView } from './views/PlanningView';
+import './index.css';
+
+const queryClient = new QueryClient();
+const rootRoute = createRootRoute({
+  component: () => (
+    <div className="min-h-screen bg-slate-100 text-slate-900">
+      <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 py-8">
+        <header className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold">SimOEM</h1>
+            <p className="text-sm text-slate-600">Maxis-style automotive OEM simulation</p>
+          </div>
+          <nav className="flex gap-4 text-sm">
+            <Link to="/" className="text-slate-600 hover:text-slate-900">
+              Dashboard
+            </Link>
+            <Link to="/planning" className="text-slate-600 hover:text-slate-900">
+              Planning
+            </Link>
+          </nav>
+        </header>
+        <Outlet />
+      </div>
+    </div>
+  ),
+});
+
+const dashboardRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/',
+  component: DashboardView,
+});
+
+const planningRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/planning',
+  component: PlanningView,
+});
+
+const routeTree = rootRoute.addChildren([dashboardRoute, planningRoute]);
+const router = createRouter({ routeTree });
+
+const rootElement = document.getElementById('root');
+if (!rootElement) throw new Error('Root element not found');
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/apps/web/src/testSetup.ts
+++ b/apps/web/src/testSetup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/apps/web/src/views/DashboardView.test.tsx
+++ b/apps/web/src/views/DashboardView.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DashboardView } from './DashboardView';
+
+describe('DashboardView', () => {
+  it('renders action buttons', () => {
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <DashboardView />
+      </QueryClientProvider>
+    );
+
+    expect(screen.getByText(/New Game/i)).toBeInTheDocument();
+    expect(screen.getByText(/Advance Month/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/views/DashboardView.tsx
+++ b/apps/web/src/views/DashboardView.tsx
@@ -1,0 +1,82 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { KpiTile } from '../components/KpiTile';
+import { HistoryChart } from '../components/HistoryChart';
+import { fetchHistory, startNewSim, tickSim } from '../hooks/useSimApi';
+
+function formatCurrency(value?: number) {
+  if (!value && value !== 0) return '—';
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(value);
+}
+
+export function DashboardView() {
+  const queryClient = useQueryClient();
+  const historyQuery = useQuery({ queryKey: ['history'], queryFn: fetchHistory });
+
+  const newGame = useMutation({
+    mutationFn: startNewSim,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['state'] });
+      queryClient.invalidateQueries({ queryKey: ['history'] });
+    },
+  });
+
+  const tick = useMutation({
+    mutationFn: tickSim,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['state'] });
+      queryClient.invalidateQueries({ queryKey: ['history'] });
+    },
+  });
+
+  const snapshot = historyQuery.data?.[0];
+  const kpis = snapshot?.kpis;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap gap-3">
+        <button
+          className="rounded-lg bg-slate-900 px-4 py-2 text-white shadow-sm hover:bg-slate-800"
+          onClick={() => newGame.mutate()}
+        >
+          New Game
+        </button>
+        <button
+          className="rounded-lg bg-blue-600 px-4 py-2 text-white shadow-sm hover:bg-blue-500"
+          onClick={() => tick.mutate()}
+        >
+          Advance Month
+        </button>
+      </div>
+      <div className="grid gap-4 md:grid-cols-3">
+        <KpiTile label="EBITDA %" value={kpis ? `${(kpis.ebitdaPct * 100).toFixed(1)}%` : '—'} />
+        <KpiTile label="Cash" value={formatCurrency(kpis?.cash)} helper="Current cash balance" />
+        <KpiTile label="Warranty $/unit" value={kpis ? formatCurrency(kpis.warrantyPerUnit) : '—'} />
+      </div>
+      <HistoryChart
+        data={(historyQuery.data ?? []).map((item: any) => ({
+          month: item.month,
+          cash: item.kpis.cash,
+          sales: Object.values(item.deltas.sales ?? {}).reduce((sum: number, val: any) => sum + (typeof val === 'number' ? val : 0), 0),
+        }))}
+      />
+      <section className="grid gap-4 md:grid-cols-2">
+        <div className="rounded-lg border border-dashed border-slate-300 bg-white p-4">
+          <h2 className="text-lg font-semibold">Market Allocation</h2>
+          <p className="mt-2 text-sm text-slate-600">
+            Quick overview of demand and supply by market. This prototype renders aggregated values from the latest snapshot.
+          </p>
+          <pre className="mt-4 overflow-auto rounded bg-slate-900 p-4 text-xs text-slate-100">
+            {JSON.stringify(kpis?.marketShare ?? {}, null, 2)}
+          </pre>
+        </div>
+        <div className="rounded-lg border border-dashed border-slate-300 bg-white p-4">
+          <h2 className="text-lg font-semibold">CO₂ Compliance</h2>
+          <p className="mt-2 text-sm text-slate-600">Track the gap to market targets and identify the need for credits or fines.</p>
+          <pre className="mt-4 overflow-auto rounded bg-slate-900 p-4 text-xs text-slate-100">
+            {JSON.stringify(kpis?.co2Gap ?? {}, null, 2)}
+          </pre>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/views/PlanningView.tsx
+++ b/apps/web/src/views/PlanningView.tsx
@@ -1,0 +1,40 @@
+import { useMutation } from '@tanstack/react-query';
+import { usePlanStore } from '../hooks/usePlanStore';
+import { submitPlan } from '../hooks/useSimApi';
+
+export function PlanningView() {
+  const pricing = usePlanStore((state) => state.pricing);
+  const setPricing = usePlanStore((state) => state.setPricing);
+  const mutation = useMutation({ mutationFn: submitPlan });
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold">Planning Drawer</h2>
+        <p className="text-sm text-slate-600">Create incentive or pricing updates for the next month.</p>
+      </div>
+      <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+        <h3 className="font-semibold">Pricing Overrides</h3>
+        <button
+          className="mt-3 rounded border border-dashed border-slate-400 px-3 py-2 text-sm"
+          onClick={() => setPricing([...pricing, { trimId: 1, marketId: 1, incentivePerUnit: 500 }])}
+        >
+          Add Example Incentive
+        </button>
+        <pre className="mt-4 rounded bg-slate-900 p-4 text-xs text-slate-100">{JSON.stringify(pricing, null, 2)}</pre>
+        <button
+          className="mt-4 rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white"
+          onClick={() => mutation.mutate({ pricing, allocationRules: { marketPriority: { 1: 1 }, dealerCSIWeight: 1, fairnessMin: 5 } })}
+        >
+          Submit Plan
+        </button>
+      </div>
+      {mutation.error && (
+        <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {(mutation.error as any)?.response?.data?.error?.message ?? 'Validation failed'}
+        </div>
+      )}
+      {mutation.isSuccess && <div className="text-sm text-green-600">Plan accepted for next tick.</div>}
+    </div>
+  );
+}

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": ["src", "vite.config.ts", "tailwind.config.ts"]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/testSetup.ts'],
+  },
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: simoem
+      POSTGRES_DB: simoem
+      POSTGRES_USER: simoem
+    ports:
+      - '5432:5432'
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    env_file: .env
+    depends_on:
+      - db
+    ports:
+      - '3333:3333'
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.web
+    depends_on:
+      - api
+    ports:
+      - '5173:5173'

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,17 @@
+# API Reference
+
+Base URL defaults to `http://localhost:3333`.
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/api/sim/config` | Retrieve the active simulation config with balancing knobs. |
+| POST | `/api/sim/new` | Start a new simulation with the default scenario. Returns the initial snapshot. |
+| POST | `/api/sim/tick` | Advance one month using the previously submitted plan. Returns the new snapshot. |
+| POST | `/api/actions/plan` | Validate and stage planning inputs for the next tick. |
+| GET | `/api/sim/state` | Inspect the current authoritative sim state. |
+| GET | `/api/sim/history?from&to` | Fetch historical snapshots in the given window. |
+| POST | `/api/save` | Persist the active sim to `UserSave` (stubbed in v1). |
+| GET | `/api/save` | List existing saves. |
+| POST | `/api/load` | Load a saved game (v1 proxies to `new`). |
+
+Errors follow the shape `{ error: { code, message, details? } }`. POST bodies use the `SimInputPlan` contract defined in `packages/engine`.

--- a/docs/BALANCING.md
+++ b/docs/BALANCING.md
@@ -1,0 +1,32 @@
+# Balancing & Tuning Guide
+
+The `SimConfig.rules` JSON stores coefficients surfaced here for quick tuning. Modify the Prisma seed or admin UI (future) to adjust.
+
+## Demand
+- `availabilitySigmoid.mid`: Days-supply midpoint where availability factor equals ~0.7. Lower it for more aggressive stocking penalties.
+- `availabilitySigmoid.steepness`: Sharpness of the sigmoid. Increase for harsher swings.
+- `elasticityBySegment`: Price sensitivity (0.6–1.4). Higher numbers mean incentives materially lift demand.
+- `campaignLiftScalar`: Converts marketing spend to demand lift. Default `0.00015` ≈ +1.5% per $1M.
+
+## Macro Weights
+- `macroWeights.gdp`: GDP index sensitivity (positive).
+- `macroWeights.interest`: Interest rate penalty (negative).
+- `macroWeights.fuel`: Fuel price impact (positive for efficient vehicles).
+
+## Manufacturing
+- `logisticCostPerUnit`: Included in margin calculation, representing freight + port costs.
+- Plant `bottlenecks`: Units-per-month per station. The engine takes the minimum after changeover loss.
+- `changeoverMins`: Larger changeovers reduce throughput when mix is volatile.
+
+## Warranty
+- `warranty.baseRate`: Baseline accrual in dollars per unit.
+- `warranty.complexityBase`: Scalar added per feature count.
+- `warranty.powertrainComplexity`: Multipliers by powertrain type.
+
+## CO₂
+- `co2.finePerGram`: Penalty for each gram over target. Combine with `co2Gap` output for fines/credits.
+
+### Difficulty Nudges
+- Increase `boardExpectations` cash/EBITDA targets in the save payload.
+- Adjust scenario JSON weights to spawn more negative events.
+- Modify `brandAffinity` or macro indices per market to simulate economic shocks.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,26 @@
+# Architecture & Design
+
+SimOEM is a pnpm workspace with three core layers:
+
+1. **Simulation Engine (`packages/engine`)** – Pure TypeScript functions implementing the deterministic month-tick loop. It exports typed helpers (`advanceMonth`, demand, warranty, allocation) and the shared type contracts consumed by the API and UI. All randomness is seeded via `seedrandom`.
+2. **API (`apps/api`)** – Express server exposing REST endpoints for sim control, state inspection, and persistence. Prisma manages the PostgreSQL/SQLite database. The API orchestrates plans coming from the client, applies Zod validation, invokes the engine, and stores snapshots.
+3. **Web (`apps/web`)** – Vite + React front-end with TanStack Router/Query, Zustand for local planning drafts, and Recharts for visualization. The UI surfaces KPIs, plan editors, and history charts. In development builds, the debug panel (future enhancement) can tweak coefficients at runtime.
+
+Shared UI primitives live in `packages/ui-kit`. Database schema and seeds reside in `/prisma`. Scenario definitions are JSON packs in `/scenarios` that the API can apply when starting a new game.
+
+![Flow](https://mermaid.ink/img/pako:eNp9kM1qwzAMhl9lzrJZtwgbtIt0EAoF8QFcuqHjqFucqpuoP12TLOMJf5-r9ji3mZxvIu_HO8CiAqQEd4lpPZG0AXXPpUqkgW0C0I8ru-8Q4cqHWSZGq8X2v1E-Lb8yY1ewh0mA_0-fz-6SCEQSppTQFPZWRx2AxYcK6r4hAkHLr4Hh6s5jVn2MeBGslpyVKyU6_HIYIBhTLD1sJ-ySyJcVn4O4W6tN4M1Jo9ZwAMInAYc2pR2wMBpFrRbX7UAnT_fzIjjUyDxk9S1C4dDJ71o2Tz6f83zq-dPn8ftxzt0kP-ZWC1ZjC9nblncyeYFjBvBQCmB4p2qu14U-n1Uue3sP7o4fJPAo)
+
+## Tick Flow
+
+The server calls `advanceMonth(prevState, plan, cfg, seed)` which internally executes the loop defined in the spec. The engine returns the updated state and a `SimSnapshot` containing KPIs, production/sales deltas, and messaging for the UI.
+
+## Persistence
+
+- `SimConfig` contains tunable coefficients used by the engine.
+- `SimState` stores the authoritative finance and macro-level data, while `SimSnapshot` provides history for charts.
+- `seed.ts` populates markets, trims, plants, suppliers, and tech tree nodes for a playable baseline scenario.
+
+## Front-End Data Flow
+
+The UI uses React Query to fetch config, state, and history. Planning inputs are staged in Zustand until the user submits. Upon submission, the plan is posted to `/api/actions/plan`. Clicking “Advance Month” invokes `/api/sim/tick`, which causes the API to invoke the engine and broadcast the next snapshot.
+

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,11 @@
+# Glossary
+
+| Term | Definition |
+| --- | --- |
+| **CAFE** | Corporate Average Fuel Economy. Regulatory fleet target used to calculate CO₂ gap. |
+| **CSI** | Customer Satisfaction Index. Aggregated dealer/customer feedback metric. |
+| **Days Supply** | Inventory divided by retail demand. Used for availability penalty. |
+| **OEE** | Overall Equipment Effectiveness. Plant efficiency factor used in bottleneck math. |
+| **PPM** | Parts Per Million defects coming from suppliers. Drives warranty accrual adjustments. |
+| **Turn-and-Earn** | Allocation strategy weighting recent sales performance. |
+| **ZEV Credit** | Zero Emission Vehicle regulatory credit tradable across markets. |

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,25 @@
+# Installation
+
+1. Install [pnpm](https://pnpm.io/installation) and ensure Docker is available for the database container.
+2. Copy `.env.example` to `.env` in the repository root if you need to override defaults.
+3. Install dependencies and generate the Prisma client:
+
+```bash
+pnpm install
+pnpm --filter api prisma generate
+```
+
+4. Apply migrations and seed the database:
+
+```bash
+pnpm db:migrate
+pnpm db:seed
+```
+
+5. Start the development stack:
+
+```bash
+pnpm dev
+```
+
+The API runs on `http://localhost:3333` and the web client on `http://localhost:5173`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# SimOEM Documentation
+
+SimOEM is a deterministic month-tick simulation of the automotive industry. The docs folder contains references for new contributors:
+
+- [`INSTALL.md`](./INSTALL.md) – local setup and toolchain guidance.
+- [`DESIGN.md`](./DESIGN.md) – architecture, module boundaries, and data flow.
+- [`GLOSSARY.md`](./GLOSSARY.md) – automotive and simulation terminology.
+- [`BALANCING.md`](./BALANCING.md) – coefficients, heuristics, and live-tuning strategies.
+- [`API.md`](./API.md) – HTTP interface description.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "sim-oem",
+  "version": "1.0.0",
+  "private": true,
+  "packageManager": "pnpm@8.15.4",
+  "scripts": {
+    "dev": "concurrently --kill-others-on-fail \"pnpm --filter api dev\" \"pnpm --filter web dev\"",
+    "test": "pnpm lint && pnpm test:engine && pnpm --filter api test && pnpm --filter web test && pnpm test:e2e",
+    "test:engine": "pnpm --filter engine test",
+    "test:e2e": "playwright test",
+    "lint": "pnpm eslint .",
+    "db:migrate": "pnpm --filter api prisma migrate deploy",
+    "db:seed": "pnpm --filter api prisma db seed"
+  },
+  "devDependencies": {
+    "@commitlint/cli": "18.6.1",
+    "@commitlint/config-conventional": "18.6.2",
+    "@types/node": "20.11.19",
+    "@typescript-eslint/eslint-plugin": "6.21.0",
+    "@typescript-eslint/parser": "6.21.0",
+    "concurrently": "8.2.2",
+    "eslint": "8.57.0",
+    "eslint-config-prettier": "9.1.0",
+    "husky": "9.0.11",
+    "lint-staged": "15.2.2",
+    "playwright": "1.41.2",
+    "prettier": "3.2.5",
+    "typescript": "5.3.3"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx,json,md}": "prettier --write"
+  },
+  "commitlint": {
+    "extends": ["@commitlint/config-conventional"]
+  },
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ]
+}

--- a/packages/engine/__tests__/fixtures/baseState.json
+++ b/packages/engine/__tests__/fixtures/baseState.json
@@ -1,0 +1,23 @@
+{
+  "id": "fixture",
+  "currentMonth": 0,
+  "cash": 350000000,
+  "debt": 125000000,
+  "boardExpectations": {},
+  "trims": [],
+  "inventories": [],
+  "macro": {},
+  "brandAffinity": {},
+  "plants": [],
+  "warrantyModel": {
+    "baseRate": 600,
+    "complexityFactor": 1.05,
+    "supplierPpmFactor": 1,
+    "oeeFactor": 1
+  },
+  "allocationRule": {
+    "marketPriority": {},
+    "dealerCSIWeight": 1,
+    "fairnessMin": 5
+  }
+}

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "engine",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsup src/index.ts --dts",
+    "test": "vitest run",
+    "lint": "eslint src --ext ts"
+  },
+  "dependencies": {
+    "seedrandom": "3.0.5",
+    "zod": "3.22.4"
+  },
+  "devDependencies": {
+    "tsup": "7.2.0",
+    "vitest": "1.2.1",
+    "@types/seedrandom": "3.0.8"
+  }
+}

--- a/packages/engine/src/__tests__/math.test.ts
+++ b/packages/engine/src/__tests__/math.test.ts
@@ -1,0 +1,129 @@
+import seedrandom from 'seedrandom';
+import {
+  advanceMonth,
+  allocationScores,
+  bottleneckThroughput,
+  demandFormula,
+  featureScore,
+  warrantyAccrual,
+} from '../math';
+import { SimConfig, SimInputPlan, SimState, Trim } from '../types';
+
+describe('engine math', () => {
+  const trim: Trim = {
+    id: 'trim-a',
+    programId: 'prog-1',
+    segmentId: 'suv-c',
+    powertrain: 'bev',
+    msrp: 45000,
+    featureVector: { tech: 1.1, safety: 1.05, range: 1.2 },
+    buildCost: { base: 28000, battery: 9000 },
+    batteryKWh: 82,
+    rangeMiles: 310,
+    adasLevel: 2,
+    variableMargins: {},
+  };
+  const cfg: SimConfig = {
+    name: 'default',
+    rules: {
+      availabilitySigmoid: { mid: 60, steepness: 0.05 },
+      elasticityBySegment: { 'suv-c': 1.1 },
+      baseSegmentDemand: { 'suv-c': 24000 },
+      macroWeights: { gdp: 0.4, interest: -0.5, fuel: 0.2 },
+      logisticCostPerUnit: 750,
+      campaignLiftScalar: 0.0002,
+      warranty: {
+        complexityBase: 1.1,
+        powertrainComplexity: { bev: 1.3 },
+      },
+      co2: { finePerGram: 50 },
+    },
+  };
+
+  const baseState: SimState = {
+    id: 'sim-1',
+    currentMonth: 0,
+    cash: 500_000_000,
+    debt: 100_000_000,
+    boardExpectations: {},
+    trims: [trim],
+    inventories: [
+      { trimId: 'trim-a', marketId: 'na', dealerId: 'dealer-1', qty: 120, ageDays: 20 },
+      { trimId: 'trim-a', marketId: 'eu', dealerId: 'dealer-2', qty: 90, ageDays: 20 },
+    ],
+    macro: {
+      na: { gdpIdx: 1.02, interestRateIdx: 0.95, fuelPriceIdx: 1.1 },
+      eu: { gdpIdx: 0.99, interestRateIdx: 1.1, fuelPriceIdx: 1.2 },
+    },
+    brandAffinity: { na: 1.05, eu: 0.97 },
+    plants: [
+      { id: 'plant-1', oee: 0.9, changeoverMins: 120, bottlenecks: { body: 2800, paint: 2600 } },
+    ],
+    warrantyModel: {
+      baseRate: 800,
+      complexityFactor: 1.1,
+      supplierPpmFactor: 1.05,
+      oeeFactor: 0.98,
+    },
+    allocationRule: {
+      marketPriority: { na: 1.1, eu: 0.9 },
+      dealerCSIWeight: 1,
+      fairnessMin: 5,
+    },
+  };
+
+  const plan: SimInputPlan = {
+    pricing: [
+      { trimId: 'trim-a', marketId: 'na', incentivePerUnit: 500 },
+      { trimId: 'trim-a', marketId: 'eu', incentivePerUnit: 300 },
+    ],
+    rAndD: [],
+    contracts: [],
+    productionPlan: [{ plantId: 'plant-1', trimId: 'trim-a', volume: 5000, month: 0 }],
+    campaigns: [{ marketId: 'na', type: 'awareness', spend: 1_000_000, startMonth: 0, endMonth: 3 }],
+    allocationRules: baseState.allocationRule,
+  };
+
+  it('calculates demand using macro, price, feature, availability, and campaigns', () => {
+    const demand = demandFormula(
+      {
+        trim,
+        segmentElasticity: cfg.rules.elasticityBySegment['suv-c'],
+        macro: baseState.macro.na,
+        baseSegmentDemand: cfg.rules.baseSegmentDemand['suv-c'],
+        brandAffinity: baseState.brandAffinity.na,
+        priceGap: -0.02,
+        featureScore: featureScore(trim),
+        daysSupply: 45,
+        campaignLift: plan.campaigns[0].spend * cfg.rules.campaignLiftScalar,
+      },
+      cfg
+    );
+    expect(demand).toBeGreaterThan(0);
+    expect(demand).toBeGreaterThan(cfg.rules.baseSegmentDemand['suv-c']);
+  });
+
+  it('computes warranty accrual scaling with complexity and powertrain', () => {
+    const accrual = warrantyAccrual(trim, baseState.warrantyModel);
+    expect(accrual).toBeGreaterThan(baseState.warrantyModel.baseRate);
+  });
+
+  it('caps production via bottlenecks and changeover loss', () => {
+    const throughput = bottleneckThroughput(baseState.plants[0], 5000, 4);
+    expect(throughput).toBeLessThanOrEqual(5000);
+  });
+
+  it('scores allocation consistent with priorities and fairness', () => {
+    const rng = seedrandom('alloc');
+    const scores = allocationScores(baseState.inventories, { 'dealer-1': 50, 'dealer-2': 30 }, baseState.allocationRule, rng);
+    expect(Object.keys(scores)).toHaveLength(2);
+    expect(scores['dealer-1']).toBeGreaterThan(0);
+  });
+
+  it('advances deterministically with same seed', () => {
+    const first = advanceMonth(baseState, plan, cfg, 'seed');
+    const second = advanceMonth(baseState, plan, cfg, 'seed');
+    expect(first.snapshot.kpis.cash).toEqual(second.snapshot.kpis.cash);
+    expect(first.snapshot.deltas.production).toEqual(second.snapshot.deltas.production);
+  });
+});

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './math';

--- a/packages/engine/src/math.ts
+++ b/packages/engine/src/math.ts
@@ -1,0 +1,234 @@
+import seedrandom from 'seedrandom';
+import {
+  AllocationRule,
+  DealerInventory,
+  MacroContext,
+  Plant,
+  ProductionPlanEntry,
+  SimConfig,
+  SimInputPlan,
+  SimSnapshot,
+  SimState,
+  Trim,
+} from './types';
+
+const WORK_MINS_IN_MONTH = 30 * 24 * 60;
+
+export type DemandContext = {
+  trim: Trim;
+  segmentElasticity: number;
+  macro: MacroContext;
+  baseSegmentDemand: number;
+  brandAffinity: number;
+  priceGap: number;
+  featureScore: number;
+  daysSupply: number;
+  campaignLift: number;
+};
+
+export function demandFormula(ctx: DemandContext, cfg: SimConfig): number {
+  const macroMultiplier =
+    1 +
+    cfg.rules.macroWeights.gdp * (ctx.macro.gdpIdx - 1) +
+    cfg.rules.macroWeights.interest * (ctx.macro.interestRateIdx - 1) +
+    cfg.rules.macroWeights.fuel * (ctx.macro.fuelPriceIdx - 1);
+  const priceMultiplier = 1 - ctx.priceGap * ctx.segmentElasticity;
+  const availability = availabilityFactor(ctx.daysSupply, cfg);
+  return (
+    ctx.baseSegmentDemand *
+    macroMultiplier *
+    ctx.brandAffinity *
+    priceMultiplier *
+    ctx.featureScore *
+    availability *
+    (1 + ctx.campaignLift)
+  );
+}
+
+export function availabilityFactor(daysSupply: number, cfg: SimConfig): number {
+  const { mid, steepness } = cfg.rules.availabilitySigmoid;
+  const exponent = -steepness * (daysSupply - mid);
+  const logistic = 1 / (1 + Math.exp(exponent));
+  return 0.4 + 0.6 * logistic;
+}
+
+export function featureScore(trim: Trim): number {
+  const features = Object.values(trim.featureVector ?? {});
+  if (features.length === 0) return 1;
+  const avg = features.reduce((acc, val) => acc + val, 0) / features.length;
+  const rangeBoost = trim.rangeMiles ? Math.min(trim.rangeMiles / 300, 1.2) : 1;
+  const adasBoost = 1 + trim.adasLevel * 0.05;
+  return Math.min(1.3, Math.max(0.7, avg * rangeBoost * adasBoost));
+}
+
+export function computeMarginPerUnit(trim: Trim, incentive: number, warrantyAccrual: number, cfg: SimConfig): number {
+  const buildCost = Object.values(trim.buildCost ?? {}).reduce((sum, val) => sum + val, 0);
+  const logistics = cfg.rules.logisticCostPerUnit;
+  return trim.msrp - (buildCost + logistics + incentive + warrantyAccrual);
+}
+
+export function warrantyAccrual(trim: Trim, model: SimState['warrantyModel']): number {
+  const complexity = model.complexityFactor + Object.keys(trim.featureVector ?? {}).length * 0.02;
+  const powertrainComplexity = model.complexityFactor * (trim.powertrain === 'bev' ? 1.3 : trim.powertrain === 'phev' ? 1.2 : trim.powertrain === 'hev' ? 1.1 : 1);
+  return model.baseRate * complexity * powertrainComplexity * model.supplierPpmFactor * model.oeeFactor;
+}
+
+export function co2Gap(salesMix: Record<string, number>, target: number): number {
+  const weighted = Object.values(salesMix).reduce((acc, val) => acc + val, 0);
+  if (weighted === 0) return 0;
+  return weighted - target;
+}
+
+export function bottleneckThroughput(plant: Plant, plannedVolume: number, switches: number): number {
+  const stationCapacities = Object.values(plant.bottlenecks ?? {});
+  if (stationCapacities.length === 0) return plannedVolume;
+  const base = Math.min(...stationCapacities);
+  const changeoverLoss = (plant.changeoverMins * switches) / WORK_MINS_IN_MONTH;
+  const effective = base * (1 - changeoverLoss) * plant.oee;
+  return Math.max(0, Math.min(plannedVolume, effective));
+}
+
+export function allocationScores(
+  inventories: DealerInventory[],
+  salesHistory: Record<string, number>,
+  rule: AllocationRule,
+  rng: seedrandom.prng
+): Record<string, number> {
+  const scores: Record<string, number> = {};
+  inventories.forEach((inv) => {
+    const sales = salesHistory[inv.dealerId] ?? 0.1;
+    const invQty = Math.max(inv.qty, rule.fairnessMin);
+    const marketWeight = rule.marketPriority[inv.marketId] ?? 1;
+    const jitter = 0.95 + rng() * 0.1;
+    scores[inv.dealerId] = ((sales / invQty) * marketWeight * rule.dealerCSIWeight) * jitter;
+  });
+  return scores;
+}
+
+export function applyProduction(
+  plan: ProductionPlanEntry[],
+  plants: Plant[],
+  rng: seedrandom.prng
+): { produced: Record<string, number>; messages: SimSnapshot['messages'] } {
+  const produced: Record<string, number> = {};
+  const messages: SimSnapshot['messages'] = [];
+  plan.forEach((entry) => {
+    const plant = plants.find((p) => p.id === entry.plantId);
+    if (!plant) {
+      messages.push({ severity: 'warning', text: `Unknown plant ${entry.plantId}`, ref: 'production' });
+      return;
+    }
+    const switches = Math.max(0, Math.round(rng() * 3));
+    const throughput = bottleneckThroughput(plant, entry.volume, switches);
+    produced[entry.trimId] = (produced[entry.trimId] ?? 0) + throughput;
+    if (throughput < entry.volume) {
+      messages.push({
+        severity: 'warning',
+        text: `Plant ${plant.id} limited ${entry.trimId} to ${Math.round(throughput)} units due to bottleneck`,
+        ref: 'bottleneck',
+      });
+    }
+  });
+  return { produced, messages };
+}
+
+export function advanceMonth(
+  prevState: SimState,
+  plan: SimInputPlan,
+  cfg: SimConfig,
+  rngSeed: string
+): { nextState: SimState; snapshot: SimSnapshot } {
+  const rng = seedrandom(rngSeed + prevState.currentMonth);
+  const producedInfo = applyProduction(plan.productionPlan, prevState.plants, rng);
+  const inventoryUpdates: DealerInventory[] = prevState.inventories.map((inv) => ({
+    ...inv,
+    qty: inv.qty + Math.floor((producedInfo.produced[inv.trimId] ?? 0) / prevState.inventories.length),
+    ageDays: inv.ageDays + 30,
+  }));
+
+  const salesByMarket: Record<string, number> = {};
+  const daysSupplyByMarket: Record<string, number> = {};
+  const messages = [...producedInfo.messages];
+
+  const planPricingMap = new Map<string, number>();
+  plan.pricing.forEach((p) => {
+    planPricingMap.set(`${p.trimId}:${p.marketId}`, p.msrp ?? 0);
+  });
+
+  inventoryUpdates.forEach((inv) => {
+    const trim = prevState.trims.find((t) => t.id === inv.trimId);
+    if (!trim) return;
+    const macro = prevState.macro[inv.marketId];
+    const baseDemand = cfg.rules.baseSegmentDemand[trim.segmentId] ?? 1000;
+    const elasticity = cfg.rules.elasticityBySegment[trim.segmentId] ?? 1.0;
+    const brandAffinity = prevState.brandAffinity[inv.marketId] ?? 1;
+    const marketInventory = inventoryUpdates
+      .filter((item) => item.marketId === inv.marketId)
+      .reduce((sum, item) => sum + item.qty, 0);
+    const daysSupply = marketInventory / Math.max(1, baseDemand / 12);
+    daysSupplyByMarket[inv.marketId] = daysSupply;
+    const campaign = plan.campaigns.find((c) => c.marketId === inv.marketId && c.startMonth <= prevState.currentMonth && c.endMonth >= prevState.currentMonth);
+    const msrpOverride = planPricingMap.get(`${trim.id}:${inv.marketId}`);
+    const priceGap = msrpOverride ? (msrpOverride - trim.msrp) / trim.msrp : 0;
+    const feature = featureScore(trim);
+    const demand = demandFormula(
+      {
+        trim,
+        segmentElasticity: elasticity,
+        macro,
+        baseSegmentDemand: baseDemand,
+        brandAffinity,
+        priceGap,
+        featureScore: feature,
+        daysSupply,
+        campaignLift: campaign ? campaign.spend * cfg.rules.campaignLiftScalar : 0,
+      },
+      cfg
+    );
+    const sales = Math.min(inv.qty, Math.max(0, Math.round(demand / 12)));
+    inv.qty -= sales;
+    salesByMarket[inv.marketId] = (salesByMarket[inv.marketId] ?? 0) + sales;
+  });
+
+  const totalSales = Object.values(salesByMarket).reduce((acc, val) => acc + val, 0);
+  const warranty = prevState.trims.map((t) => warrantyAccrual(t, prevState.warrantyModel));
+  const avgWarranty = warranty.reduce((sum, val) => sum + val, 0) / Math.max(1, warranty.length);
+  const marginPerUnit = prevState.trims.reduce((sum, trim) => {
+    const incentive = plan.pricing.find((p) => p.trimId === trim.id)?.incentivePerUnit ?? 0;
+    const warrantyCost = warrantyAccrual(trim, prevState.warrantyModel);
+    return sum + computeMarginPerUnit(trim, incentive, warrantyCost, cfg);
+  }, 0);
+  const avgMargin = marginPerUnit / Math.max(prevState.trims.length, 1);
+  const revenue = totalSales * avgMargin;
+  const ebitdaPct = totalSales === 0 ? 0 : avgMargin / (avgMargin + 1e-6);
+  const nextCash = prevState.cash + revenue;
+  const snapshot: SimSnapshot = {
+    month: prevState.currentMonth + 1,
+    kpis: {
+      ebitdaPct,
+      marketShare: salesByMarket,
+      co2Gap: Object.fromEntries(Object.keys(prevState.macro).map((market) => [market, co2Gap({ [market]: salesByMarket[market] ?? 0 }, 1000)])),
+      csiAvg: 75,
+      warrantyPerUnit: avgWarranty,
+      daysSupplyByMarket,
+      cash: nextCash,
+      freeCashFlow: revenue - 0.1 * revenue,
+    },
+    deltas: {
+      production: producedInfo.produced,
+      sales: salesByMarket,
+      inventory: inventoryUpdates.map((inv) => ({ dealerId: inv.dealerId, trimId: inv.trimId, qty: inv.qty })),
+    },
+    messages,
+  };
+
+  const nextState: SimState = {
+    ...prevState,
+    currentMonth: prevState.currentMonth + 1,
+    cash: nextCash,
+    inventories: inventoryUpdates,
+    allocationRule: plan.allocationRules ?? prevState.allocationRule,
+  };
+
+  return { nextState, snapshot };
+}

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -1,0 +1,157 @@
+export type MarketId = string;
+export type TrimId = string;
+export type PlantId = string;
+export type TechNodeId = string;
+export type SupplierId = string;
+
+export type SimConfig = {
+  name: string;
+  rules: {
+    availabilitySigmoid: {
+      mid: number;
+      steepness: number;
+    };
+    elasticityBySegment: Record<string, number>;
+    baseSegmentDemand: Record<string, number>;
+    macroWeights: {
+      gdp: number;
+      interest: number;
+      fuel: number;
+    };
+    logisticCostPerUnit: number;
+    campaignLiftScalar: number;
+    warranty: {
+      complexityBase: number;
+      powertrainComplexity: Record<string, number>;
+    };
+    co2: {
+      finePerGram: number;
+    };
+  };
+};
+
+export type BrandAffinity = Record<string, number>;
+
+export type Trim = {
+  id: TrimId;
+  programId: string;
+  segmentId: string;
+  powertrain: string;
+  msrp: number;
+  featureVector: Record<string, number>;
+  buildCost: Record<string, number>;
+  batteryKWh?: number;
+  rangeMiles?: number;
+  adasLevel: number;
+  variableMargins: Record<string, number>;
+};
+
+export type DealerInventory = {
+  trimId: TrimId;
+  marketId: MarketId;
+  dealerId: string;
+  qty: number;
+  ageDays: number;
+};
+
+export type MacroContext = {
+  gdpIdx: number;
+  interestRateIdx: number;
+  fuelPriceIdx: number;
+};
+
+export type WarrantyModel = {
+  baseRate: number;
+  complexityFactor: number;
+  supplierPpmFactor: number;
+  oeeFactor: number;
+};
+
+export type AllocationRule = {
+  marketPriority: Record<MarketId, number>;
+  dealerCSIWeight: number;
+  fairnessMin: number;
+};
+
+export type Plant = {
+  id: PlantId;
+  oee: number;
+  changeoverMins: number;
+  bottlenecks: Record<string, number>;
+};
+
+export type ProductionPlanEntry = {
+  plantId: PlantId;
+  trimId: TrimId;
+  volume: number;
+  month: number;
+};
+
+export type SimInputPlan = {
+  pricing: Array<{
+    trimId: TrimId;
+    marketId: MarketId;
+    msrp?: number;
+    incentivePerUnit?: number;
+    aprSubvent?: number;
+    leaseMF?: number;
+    residualPct?: number;
+  }>;
+  rAndD: Array<{
+    techNodeId: TechNodeId;
+    action: 'start' | 'pause' | 'cancel';
+  }>;
+  contracts: Array<{
+    supplierId: SupplierId;
+    partId?: string;
+    action: 'sign' | 'renegotiate' | 'terminate';
+    terms: any;
+  }>;
+  productionPlan: ProductionPlanEntry[];
+  campaigns: Array<{
+    marketId: MarketId;
+    type: string;
+    spend: number;
+    startMonth: number;
+    endMonth: number;
+  }>;
+  allocationRules: AllocationRule;
+};
+
+export type KPIRecord = {
+  ebitdaPct: number;
+  marketShare: Record<string, number>;
+  co2Gap: Record<string, number>;
+  csiAvg: number;
+  warrantyPerUnit: number;
+  daysSupplyByMarket: Record<string, number>;
+  cash: number;
+  freeCashFlow: number;
+};
+
+export type SimSnapshot = {
+  month: number;
+  kpis: KPIRecord;
+  deltas: Record<string, any>;
+  messages: Array<{ severity: 'info' | 'warning' | 'critical'; text: string; ref?: string }>;
+};
+
+export type SimState = {
+  id: string;
+  currentMonth: number;
+  cash: number;
+  debt: number;
+  boardExpectations: Record<string, any>;
+  trims: Trim[];
+  inventories: DealerInventory[];
+  macro: Record<MarketId, MacroContext>;
+  brandAffinity: BrandAffinity;
+  plants: Plant[];
+  warrantyModel: WarrantyModel;
+  allocationRule: AllocationRule;
+};
+
+export type AdvanceResult = {
+  nextState: SimState;
+  snapshot: SimSnapshot;
+};

--- a/packages/engine/tsconfig.json
+++ b/packages/engine/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src", "../engine/__tests__/**/*.ts"]
+}

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ui-kit",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "clsx": "2.1.0",
+    "react": "18.2.0"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0"
+  }
+}

--- a/packages/ui-kit/src/Card.tsx
+++ b/packages/ui-kit/src/Card.tsx
@@ -1,0 +1,16 @@
+import { PropsWithChildren } from 'react';
+import clsx from 'clsx';
+
+type CardProps = PropsWithChildren<{
+  title?: string;
+  className?: string;
+}>;
+
+export function Card({ title, children, className }: CardProps) {
+  return (
+    <div className={clsx('rounded-lg border border-slate-200 bg-white p-4 shadow-sm', className)}>
+      {title && <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500">{title}</h3>}
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -1,0 +1,1 @@
+export * from './Card';

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:5173',
+    timeout: 120000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,244 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = env("DATABASE_PROVIDER")
+  url      = env("DATABASE_URL")
+}
+
+model Market {
+  id             Int      @id @default(autoincrement())
+  name           String
+  region         String
+  currency       String
+  co2Target      Float
+  zevCreditPrice Float
+  fuelPriceIdx   Float
+  interestRateIdx Float
+  gdpIdx         Float
+  dealers        Dealer[]
+  campaigns      Campaign[]
+  pricing        Pricing[]
+}
+
+model Segment {
+  id   Int    @id @default(autoincrement())
+  code String @unique
+  name String
+  programs Program[]
+}
+
+model Platform {
+  id         Int     @id @default(autoincrement())
+  name       String
+  type       String
+  startYear  Int
+  endYear    Int?
+  rAndDCost  Float
+  programs   Program[]
+}
+
+model Program {
+  id         Int      @id @default(autoincrement())
+  name       String
+  platform   Platform @relation(fields: [platformId], references: [id])
+  platformId Int
+  segment    Segment  @relation(fields: [segmentId], references: [id])
+  segmentId  Int
+  startMonth Int
+  status     String
+  trims      Trim[]
+}
+
+model Trim {
+  id             Int       @id @default(autoincrement())
+  program        Program   @relation(fields: [programId], references: [id])
+  programId      Int
+  powertrain     String
+  msrp           Float
+  featureVector  Json
+  buildCost      Json
+  batteryKWh     Float?
+  rangeMiles     Float?
+  adasLevel      Int
+  variableMargins Json
+  inventories    Inventory[]
+  pricing        Pricing[]
+}
+
+model Plant {
+  id                 Int     @id @default(autoincrement())
+  name               String
+  region             String
+  capacityJobsPerHour Int
+  oee                Float
+  energyMix          String
+  bottlenecks        Json
+  changeoverMins     Int
+  productionPlans    ProductionPlan[]
+}
+
+model Supplier {
+  id            Int      @id @default(autoincrement())
+  name          String
+  partCategory  String
+  leadTimeMonths Int
+  ppm           Float
+  minOrderQty   Int
+  priceCurve    Json
+  riskScore     Float
+  parts         Part[]
+  contracts     Contract[]
+}
+
+model Part {
+  id           Int      @id @default(autoincrement())
+  supplier     Supplier @relation(fields: [supplierId], references: [id])
+  supplierId   Int
+  code         String
+  name         String
+  unitCostBase Float
+  category     String
+  contracts    Contract[]
+}
+
+model Dealer {
+  id             Int       @id @default(autoincrement())
+  code           String
+  market         Market    @relation(fields: [marketId], references: [id])
+  marketId       Int
+  throughputIndex Float
+  csi            Float
+  evReadiness    Float
+  facilityScore  Float
+  inventory      Inventory[]
+}
+
+model Inventory {
+  id       Int   @id @default(autoincrement())
+  trim     Trim  @relation(fields: [trimId], references: [id])
+  trimId   Int
+  dealer   Dealer @relation(fields: [dealerId], references: [id])
+  dealerId Int
+  ageDays  Int
+  qty      Int
+}
+
+model Campaign {
+  id                Int    @id @default(autoincrement())
+  market            Market @relation(fields: [marketId], references: [id])
+  marketId          Int
+  type              String
+  spend             Float
+  startMonth        Int
+  endMonth          Int
+  awarenessLift     Float
+  considerationLift Float
+}
+
+model Contract {
+  id         Int      @id @default(autoincrement())
+  supplier   Supplier @relation(fields: [supplierId], references: [id])
+  supplierId Int
+  part       Part?    @relation(fields: [partId], references: [id])
+  partId     Int?
+  terms      Json
+  startMonth Int
+  endMonth   Int
+  dualSourceRank Int
+}
+
+model TechNode {
+  id             Int    @id @default(autoincrement())
+  code           String @unique
+  name           String
+  cost           Float
+  timeMonths     Int
+  risk           Float
+  featureImpact  Json
+  regScoreImpact Float
+  prereqs        Json
+  researches     Research[]
+}
+
+model Research {
+  id         Int      @id @default(autoincrement())
+  techNode   TechNode @relation(fields: [techNodeId], references: [id])
+  techNodeId Int
+  startMonth Int
+  progress   Float
+  status     String
+}
+
+model EventCard {
+  id          Int    @id @default(autoincrement())
+  code        String @unique
+  name        String
+  description String
+  effects     Json
+  weight      Float
+}
+
+model SimConfig {
+  id    Int   @id @default(autoincrement())
+  name  String
+  rules Json
+}
+
+model SimState {
+  id                 Int          @id @default(autoincrement())
+  currentMonth       Int
+  cash               Float
+  debt               Float
+  boardExpectations  Json
+  snapshots          SimSnapshot[]
+}
+
+model SimSnapshot {
+  id         Int      @id @default(autoincrement())
+  simState   SimState @relation(fields: [simStateId], references: [id])
+  simStateId Int
+  month      Int
+  kpis       Json
+  deltas     Json
+}
+
+model Pricing {
+  id             Int   @id @default(autoincrement())
+  trim           Trim  @relation(fields: [trimId], references: [id])
+  trimId         Int
+  market         Market @relation(fields: [marketId], references: [id])
+  marketId       Int
+  msrp           Float
+  incentivePerUnit Float
+  aprSubvent     Float
+  leaseMF        Float
+  residualPct    Float
+}
+
+model WarrantyModel {
+  id                Int   @id @default(autoincrement())
+  baseRate          Float
+  complexityFactor  Float
+  supplierPpmFactor Float
+  oeeFactor         Float
+}
+
+model UserSave {
+  id        Int      @id @default(autoincrement())
+  userId    String?
+  label     String
+  createdAt DateTime @default(now())
+  payload   Json
+}
+
+model ProductionPlan {
+  id       Int   @id @default(autoincrement())
+  plant    Plant @relation(fields: [plantId], references: [id])
+  plantId  Int
+  trim     Trim  @relation(fields: [trimId], references: [id])
+  trimId   Int
+  volume   Int
+  month    Int
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,259 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  await prisma.inventory.deleteMany();
+  await prisma.dealer.deleteMany();
+  await prisma.pricing.deleteMany();
+  await prisma.market.deleteMany();
+  await prisma.segment.deleteMany();
+  await prisma.platform.deleteMany();
+  await prisma.program.deleteMany();
+  await prisma.trim.deleteMany();
+  await prisma.plant.deleteMany();
+  await prisma.supplier.deleteMany();
+  await prisma.techNode.deleteMany();
+  await prisma.eventCard.deleteMany();
+  await prisma.simConfig.deleteMany();
+
+  const markets = await prisma.market.createMany({
+    data: [
+      {
+        name: 'North America',
+        region: 'NA',
+        currency: 'USD',
+        co2Target: 95,
+        zevCreditPrice: 150,
+        fuelPriceIdx: 1.0,
+        interestRateIdx: 1.0,
+        gdpIdx: 1.0,
+      },
+      {
+        name: 'Europe',
+        region: 'EU',
+        currency: 'EUR',
+        co2Target: 80,
+        zevCreditPrice: 200,
+        fuelPriceIdx: 1.2,
+        interestRateIdx: 1.1,
+        gdpIdx: 0.98,
+      },
+      {
+        name: 'Asia Pacific',
+        region: 'APAC',
+        currency: 'JPY',
+        co2Target: 100,
+        zevCreditPrice: 120,
+        fuelPriceIdx: 0.9,
+        interestRateIdx: 0.95,
+        gdpIdx: 1.05,
+      },
+    ],
+  });
+
+  const segments = await prisma.segment.createMany({
+    data: [
+      { code: 'SUV-C', name: 'Crossover' },
+      { code: 'SUV-D', name: 'Large Crossover' },
+      { code: 'PICKUP', name: 'Pickup' },
+      { code: 'PERF', name: 'Performance' },
+      { code: 'SED-C', name: 'Compact Sedan' },
+      { code: 'EV-C', name: 'EV Compact' },
+    ],
+  });
+
+  const platform = await prisma.platform.create({
+    data: {
+      name: 'Atlas Modular',
+      type: 'BEV',
+      startYear: 2020,
+      endYear: 2030,
+      rAndDCost: 2500000000,
+    },
+  });
+
+  const platform2 = await prisma.platform.create({
+    data: {
+      name: 'Everest Body-on-Frame',
+      type: 'ICE',
+      startYear: 2015,
+      endYear: 2028,
+      rAndDCost: 1600000000,
+    },
+  });
+
+  const suvSegment = await prisma.segment.findFirst({ where: { code: 'SUV-C' } });
+  const pickupSegment = await prisma.segment.findFirst({ where: { code: 'PICKUP' } });
+
+  const program1 = await prisma.program.create({
+    data: {
+      name: 'Aurora EV',
+      platformId: platform.id,
+      segmentId: suvSegment!.id,
+      startMonth: 0,
+      status: 'production',
+    },
+  });
+
+  const program2 = await prisma.program.create({
+    data: {
+      name: 'Frontier Truck',
+      platformId: platform2.id,
+      segmentId: pickupSegment!.id,
+      startMonth: 0,
+      status: 'production',
+    },
+  });
+
+  await prisma.trim.createMany({
+    data: [
+      {
+        programId: program1.id,
+        powertrain: 'bev',
+        msrp: 52000,
+        featureVector: { tech: 1.1, safety: 1.0, range: 1.2 },
+        buildCost: { base: 30000, battery: 12000 },
+        batteryKWh: 85,
+        rangeMiles: 310,
+        adasLevel: 2,
+        variableMargins: { na: 0.12 },
+      },
+      {
+        programId: program2.id,
+        powertrain: 'ice',
+        msrp: 42000,
+        featureVector: { tech: 0.9, safety: 0.95, towing: 1.3 },
+        buildCost: { base: 25000 },
+        adasLevel: 1,
+        variableMargins: { na: 0.15 },
+      },
+    ],
+  });
+
+  const trimRecords = await prisma.trim.findMany();
+  const marketsList = await prisma.market.findMany();
+
+  for (const market of marketsList) {
+    for (let i = 0; i < 3; i += 1) {
+      const dealer = await prisma.dealer.create({
+        data: {
+          code: `${market.region}-D${i + 1}`,
+          marketId: market.id,
+          throughputIndex: 1 + i * 0.1,
+          csi: 75 - i * 2,
+          evReadiness: 0.6 + i * 0.1,
+          facilityScore: 0.7 + i * 0.1,
+        },
+      });
+
+      await prisma.inventory.createMany({
+        data: trimRecords.map((trim) => ({
+          dealerId: dealer.id,
+          trimId: trim.id,
+          ageDays: 20,
+          qty: 60 - i * 10,
+        })),
+      });
+    }
+  }
+
+  await prisma.plant.createMany({
+    data: [
+      {
+        name: 'Detroit Assembly',
+        region: 'NA',
+        capacityJobsPerHour: 3000,
+        oee: 0.88,
+        energyMix: 'grid',
+        bottlenecks: { body: 2500, paint: 2300, general: 2800 },
+        changeoverMins: 180,
+      },
+      {
+        name: 'Saskatoon Battery Plant',
+        region: 'NA',
+        capacityJobsPerHour: 1800,
+        oee: 0.92,
+        energyMix: 'renewable',
+        bottlenecks: { pack: 1700, final: 1600 },
+        changeoverMins: 120,
+      },
+    ],
+  });
+
+  await prisma.supplier.createMany({
+    data: [
+      { name: 'Quantum Cells', partCategory: 'Battery', leadTimeMonths: 6, ppm: 15, minOrderQty: 1000, priceCurve: { base: 110 }, riskScore: 0.2 },
+      { name: 'Forge Steel', partCategory: 'Frame', leadTimeMonths: 4, ppm: 40, minOrderQty: 2000, priceCurve: { base: 45 }, riskScore: 0.4 },
+      { name: 'Bright Optics', partCategory: 'Lighting', leadTimeMonths: 2, ppm: 12, minOrderQty: 1500, priceCurve: { base: 25 }, riskScore: 0.15 },
+      { name: 'SkyChip', partCategory: 'Semiconductor', leadTimeMonths: 8, ppm: 35, minOrderQty: 5000, priceCurve: { base: 80 }, riskScore: 0.5 },
+      { name: 'DriveLine Co', partCategory: 'Powertrain', leadTimeMonths: 5, ppm: 30, minOrderQty: 2500, priceCurve: { base: 120 }, riskScore: 0.35 },
+      { name: 'VisionSafe', partCategory: 'ADAS', leadTimeMonths: 3, ppm: 20, minOrderQty: 1200, priceCurve: { base: 60 }, riskScore: 0.25 },
+    ],
+  });
+
+  await prisma.techNode.createMany({
+    data: [
+      { code: 'ICE', name: 'Advanced ICE', cost: 200000000, timeMonths: 12, risk: 0.1, featureImpact: { efficiency: 0.02 }, regScoreImpact: -5, prereqs: [] },
+      { code: '48V', name: '48V Mild Hybrid', cost: 400000000, timeMonths: 16, risk: 0.2, featureImpact: { efficiency: 0.05 }, regScoreImpact: -10, prereqs: ['ICE'] },
+      { code: 'HEV', name: 'Full Hybrid', cost: 600000000, timeMonths: 18, risk: 0.25, featureImpact: { efficiency: 0.08 }, regScoreImpact: -15, prereqs: ['48V'] },
+      { code: 'PHEV', name: 'Plug-in Hybrid', cost: 850000000, timeMonths: 20, risk: 0.3, featureImpact: { evRange: 40 }, regScoreImpact: -25, prereqs: ['HEV'] },
+      { code: 'BEV', name: 'Battery Electric', cost: 1200000000, timeMonths: 24, risk: 0.35, featureImpact: { evRange: 250 }, regScoreImpact: -40, prereqs: ['PHEV'] },
+      { code: 'ADAS-L2', name: 'ADAS Level 2', cost: 180000000, timeMonths: 12, risk: 0.2, featureImpact: { safety: 0.1 }, regScoreImpact: 5, prereqs: [] },
+      { code: 'ADAS-L3', name: 'ADAS Level 3', cost: 420000000, timeMonths: 18, risk: 0.35, featureImpact: { safety: 0.2 }, regScoreImpact: 10, prereqs: ['ADAS-L2'] },
+    ],
+  });
+
+  await prisma.eventCard.createMany({
+    data: [
+      { code: 'chip_shortage', name: 'Chip Shortage', description: 'Global semiconductor crunch cuts supply 20%', effects: { production: 0.8 }, weight: 0.4 },
+      { code: 'port_strike', name: 'Port Strike', description: 'Logistics slowdown adds 15 days to shipping', effects: { logisticsDelay: 15 }, weight: 0.2 },
+      { code: 'ncap_downgrade', name: 'NCAP Downgrade', description: 'Safety downgrade hits CSI', effects: { csi: -5 }, weight: 0.15 },
+    ],
+  });
+
+  await prisma.simConfig.create({
+    data: {
+      name: 'default',
+      rules: {
+        availabilitySigmoid: { mid: 60, steepness: 0.05 },
+        elasticityBySegment: { 'SUV-C': 1.2, PICKUP: 0.9 },
+        baseSegmentDemand: { 'SUV-C': 24000, PICKUP: 18000 },
+        macroWeights: { gdp: 0.4, interest: -0.5, fuel: 0.25 },
+        logisticCostPerUnit: 650,
+        campaignLiftScalar: 0.00015,
+        warranty: { complexityBase: 1.05, powertrainComplexity: { bev: 1.3, phev: 1.2, hev: 1.1, ice: 1.0 } },
+        co2: { finePerGram: 50 },
+      },
+    },
+  });
+
+  const trimsFinal = await prisma.trim.findMany();
+  const dealers = await prisma.dealer.findMany();
+  for (const dealer of dealers) {
+    for (const trim of trimsFinal) {
+      await prisma.pricing.create({
+        data: {
+          trimId: trim.id,
+          marketId: dealer.marketId,
+          msrp: trim.msrp,
+          incentivePerUnit: 500,
+          aprSubvent: 0.02,
+          leaseMF: 0.0015,
+          residualPct: 0.55,
+        },
+      });
+    }
+  }
+
+  console.log('Seeded core datasets');
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/scenarios/chipageddon_2021.json
+++ b/scenarios/chipageddon_2021.json
@@ -1,0 +1,14 @@
+{
+  "name": "Chipageddon 2021",
+  "description": "Global semiconductor shortage reduces plant throughput and raises supplier risk.",
+  "deltas": {
+    "plants": { "plant-1": { "oee": 0.75 } },
+    "suppliers": { "SkyChip": { "leadTimeMonths": 12, "riskScore": 0.7 } }
+  },
+  "events": { "chip_shortage": 0.8 },
+  "objectives": {
+    "ebitdaPct": 0.08,
+    "bevMix": 0.25,
+    "cash": 400000000
+  }
+}

--- a/scenarios/ev_pivot_midcycle.json
+++ b/scenarios/ev_pivot_midcycle.json
@@ -1,0 +1,14 @@
+{
+  "name": "EV Pivot Mid-Cycle",
+  "description": "Board mandates a rapid shift to electrification mid-cycle.",
+  "deltas": {
+    "simConfig": { "rules": { "elasticityBySegment": { "EV-C": 1.4 } } },
+    "markets": { "market-2": { "co2Target": 70 } }
+  },
+  "events": { "ncap_downgrade": 0.1 },
+  "objectives": {
+    "bevMix": 0.35,
+    "co2": 0,
+    "ebitdaPct": 0.1
+  }
+}

--- a/scenarios/global_recall.json
+++ b/scenarios/global_recall.json
@@ -1,0 +1,14 @@
+{
+  "name": "Global Recall",
+  "description": "Critical component recall impacts warranty costs and CSI.",
+  "deltas": {
+    "warrantyModel": { "baseRate": 1200 },
+    "allocationRule": { "dealerCSIWeight": 1.3 }
+  },
+  "events": { "port_strike": 0.2 },
+  "objectives": {
+    "warrantyPerUnit": 800,
+    "csi": 80,
+    "cash": 300000000
+  }
+}

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('SimOEM onboarding', () => {
+  test.skip(true, 'Full E2E flow requires running API + DB. Skipping in CI until backend harness is available.');
+
+  test('can render dashboard and advance month', async ({ page }) => {
+    await page.goto('http://localhost:5173');
+    await page.getByRole('button', { name: /New Game/i }).click();
+    await expect(page.getByText(/Market Allocation/i)).toBeVisible();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "baseUrl": "."
+  },
+  "exclude": ["node_modules", "dist", "build"]
+}


### PR DESCRIPTION
## Summary
- scaffold pnpm workspace with deterministic simulation engine, Express API, and Vite React client
- add Prisma schema with seeds, scenarios, and supporting Docker/CI tooling
- implement baseline docs, testing harnesses, and shared UI components for SimOEM

## Testing
- pnpm install *(fails: registry access blocked in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68daab3907548322a652f2f2a1fd834f